### PR TITLE
add write permission for create-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -146,8 +148,6 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          name: JTaccuino Studio 1.0.0
-          body: |
-            This is the JTaccuino Studio version 1.0.0
+          generate_release_notes: true
           files: |
             ./dist/*


### PR DESCRIPTION
Fixes release job. 

It also replaces static name with tag name and body with auto-generation of release notes.