### PR TITLE
Completion overhaul on JDK 26 / JavaFX 26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,12 +60,12 @@ jobs:
         run: |
           echo JPACKAGE_HOME=$JAVA_HOME >> $GITHUB_OUTPUT
 
-      - name: Setup Java 25
-        id: java25
+      - name: Setup Java 26
+        id: java26
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 25
+          java-version: 26
 
       - uses: Apple-Actions/import-codesign-certs@v7
         if: github.event_name != 'pull_request' && (matrix.os == 'macos-13' || matrix.os == 'macos-14')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,12 +54,12 @@ jobs:
         run: |
           echo JPACKAGE_HOME=$JAVA_HOME >> $GITHUB_OUTPUT
 
-      - name: Setup Java 25
-        id: java25
+      - name: Setup Java 26
+        id: java26
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: 25
+          java-version: 26
 
       - uses: Apple-Actions/import-codesign-certs@v7
         if: matrix.os == 'macos-13' || matrix.os == 'macos-14'

--- a/app/src/main/resources/jtaccuino.css
+++ b/app/src/main/resources/jtaccuino.css
@@ -551,8 +551,17 @@ AUTHOR: ShopWare
     -fx-font-size: 11;
 }
 
-.list-cell.type-matches {
+.list-cell.type-matches .completion-name {
     -fx-font-weight: bold;
+}
+
+.completion-name {
+    -fx-text-fill: -fx-text-background-color;
+}
+
+.completion-type {
+    -fx-text-fill: #808080;
+    -fx-font-size: 10;
 }
 
 .list-cell.separator-cell {

--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ allprojects {
             withSourcesJar()
             // Apply a specific Java toolchain to ease working on different environments.
             toolchain {
-                languageVersion.set(JavaLanguageVersion.of(25))
+                languageVersion.set(JavaLanguageVersion.of(26))
             }
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-versionJavafx=25
+versionJavafx=26
 versionYasson=3.0.3
 versionMavenResolver=2.0.5
 versionMaven=3.9.6

--- a/shell/src/main/java/org/jtaccuino/jshell/ReactiveJShell.java
+++ b/shell/src/main/java/org/jtaccuino/jshell/ReactiveJShell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 JTaccuino Contributors
+ * Copyright 2024-2026 JTaccuino Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,27 @@
 package org.jtaccuino.jshell;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.type.WildcardType;
 import jdk.jshell.DeclarationSnippet;
 import jdk.jshell.Diag;
 import jdk.jshell.ExpressionSnippet;
@@ -39,8 +50,11 @@ import org.jtaccuino.jshell.extensions.JShellExtension;
 
 public class ReactiveJShell {
 
-    private final ExecutorService worker = Executors
-            .newSingleThreadExecutor(Thread.ofVirtual().name("ReactiveJShellWorker").factory());
+    private final ExecutorService worker = new ThreadPoolExecutor(
+            1, 1, 0L, TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(),
+            Thread.ofVirtual().name("ReactiveJShellWorker").factory(),
+            new ThreadPoolExecutor.DiscardPolicy());
 
     private final JShell jshell = JShell.builder()
             .compilerOptions("--enable-preview", "-source", System.getProperty("java.specification.version"),
@@ -146,9 +160,19 @@ public class ReactiveJShell {
             Consumer<CompletionSuggestion> consumer) {
         CompletableFuture.supplyAsync(
                 () -> {
-                    int[] anchor = new int[1];
-                    var completionSuggestions = jshell.sourceCodeAnalysis().completionSuggestions(text, caretPosition, anchor);
-                    return new CompletionSuggestion(completionSuggestions, anchor[0]);
+                    int[] anchorHolder = new int[1];
+                    var completionItems = jshell.sourceCodeAnalysis().completionSuggestions(text, caretPosition,
+                            (state, elementSuggestions) -> {
+                                if (!elementSuggestions.isEmpty()) {
+                                    anchorHolder[0] = elementSuggestions.getFirst().anchor();
+                                }
+                                return elementSuggestions.stream()
+                                        .filter(suggestion -> !"module ".equals(suggestion.keyword()))
+                                        .map(CompletionItem::from)
+                                        .sorted(Comparator.comparingInt(item -> item.matchesType() ? 0 : 1))
+                                        .toList();
+                            });
+                    return new CompletionSuggestion(completionItems, anchorHolder[0]);
                 },
                 worker)
                 .thenAccept(consumer)
@@ -218,7 +242,86 @@ public class ReactiveJShell {
         System.out.println("JShell Shutdown complete");
     }
 
-    public static record CompletionSuggestion(List<SourceCodeAnalysis.Suggestion> suggestions, int anchor) {
+    public static record CompletionSuggestion(List<ReactiveJShell.CompletionItem> suggestions, int anchor) {
+    }
+
+    public static record CompletionItem(String completion, boolean matchesType, int anchor,
+            ElementKind elementKind, boolean keyword, boolean staticMember, String displayName, String typeInfo) {
+
+        static CompletionItem from(SourceCodeAnalysis.ElementSuggestion elementSuggestion) {
+            var keyword = elementSuggestion.keyword();
+            if (keyword != null) {
+                return new CompletionItem(keyword, elementSuggestion.matchesType(), elementSuggestion.anchor(), null, true, false, "", "");
+            }
+            var element = elementSuggestion.element();
+            if (element != null) {
+                var kind = element.getKind();
+                var name = element.getSimpleName().toString();
+                var staticMember = element.getModifiers().contains(Modifier.STATIC);
+                var completion = switch (kind) {
+                    case METHOD, CONSTRUCTOR -> name + "(";
+                    default -> name;
+                };
+                return switch (kind) {
+                    case METHOD -> {
+                        var executable = (ExecutableType) element.asType();
+                        yield new CompletionItem(completion, elementSuggestion.matchesType(), elementSuggestion.anchor(), kind, false,
+                                staticMember, name + "(" + simpleTypeNames(executable.getParameterTypes()) + ")",
+                                simpleTypeName(executable.getReturnType()));
+                    }
+                    case CONSTRUCTOR -> {
+                        var executable = (ExecutableType) element.asType();
+                        yield new CompletionItem(completion, elementSuggestion.matchesType(), elementSuggestion.anchor(), kind, false,
+                                staticMember, name + "(" + simpleTypeNames(executable.getParameterTypes()) + ")", "");
+                    }
+                    case FIELD, ENUM_CONSTANT, PARAMETER, LOCAL_VARIABLE, RESOURCE_VARIABLE,
+                            EXCEPTION_PARAMETER, TYPE_PARAMETER, BINDING_VARIABLE ->
+                        new CompletionItem(completion, elementSuggestion.matchesType(), elementSuggestion.anchor(), kind, false,
+                                staticMember, name, simpleTypeName(element.asType()));
+                    default ->
+                        new CompletionItem(completion, elementSuggestion.matchesType(), elementSuggestion.anchor(), kind, false,
+                                staticMember, name, "");
+                };
+            }
+            return new CompletionItem("", elementSuggestion.matchesType(), elementSuggestion.anchor(), null, true, false, "", "");
+        }
+
+        private static String simpleTypeNames(List<? extends TypeMirror> types) {
+            return String.join(", ", types.stream().map(CompletionItem::simpleTypeName).toList());
+        }
+
+        private static String simpleTypeName(TypeMirror type) {
+            return switch (type.getKind()) {
+                case DECLARED -> {
+                    var declared = (DeclaredType) type;
+                    var base = declared.asElement().getSimpleName().toString();
+                    var typeArguments = declared.getTypeArguments();
+                    if (typeArguments.isEmpty()) {
+                        yield base;
+                    }
+                    yield base + "<" + String.join(", ",
+                            typeArguments.stream().map(CompletionItem::simpleTypeName).toList()) + ">";
+                }
+                case ARRAY ->
+                    simpleTypeName(((ArrayType) type).getComponentType()) + "[]";
+                case WILDCARD -> {
+                    var wildcard = (WildcardType) type;
+                    if (wildcard.getExtendsBound() != null) {
+                        yield "? extends " + simpleTypeName(wildcard.getExtendsBound());
+                    }
+                    if (wildcard.getSuperBound() != null) {
+                        yield "? super " + simpleTypeName(wildcard.getSuperBound());
+                    }
+                    yield "?";
+                }
+                case TYPEVAR ->
+                    ((TypeVariable) type).asElement().getSimpleName().toString();
+                case VOID ->
+                    "void";
+                default ->
+                    type.toString();
+            };
+        }
     }
 
     public static record EvaluationResult(List<SnippetEvent> snippetEventsCurrent, List<SnippetEvent> snippetEventsOutdated,

--- a/ui/src/main/java/org/jtaccuino/core/ui/JavaCellFactory.java
+++ b/ui/src/main/java/org/jtaccuino/core/ui/JavaCellFactory.java
@@ -363,11 +363,6 @@ public class JavaCellFactory implements CellFactory {
                     Platform.runLater(() -> filterCompletion(input.getDocument().getText(), input.getDocument().getCaretPosition()));
                 }
             });
-            input.caretOriginProperty().addListener((observable, oldValue, newValue) -> {
-                if (completionPopup.isShowing()) {
-                    Platform.runLater(() -> completionPopup.updateLocation(input.getCaretOrigin().add(0, 13)));
-                }
-            });
         }
 
         void requestFocus() {
@@ -523,8 +518,11 @@ public class JavaCellFactory implements CellFactory {
 
         private void filterCompletion(String text, int caretPos) {
             this.control.getSheet().getReactiveJShell().completionAsync(text, caretPos, result -> {
-                var distinctCompletionSuggestions = result.suggestions().stream().map(s -> CompletionItem.from(s, result.anchor())).distinct().toList();
-                Platform.runLater(() -> completionPopup.setSuggestions(distinctCompletionSuggestions));
+                var distinctCompletionSuggestions = result.suggestions().stream().map(CompletionItem::from).distinct().toList();
+                Platform.runLater(() -> {
+                    completionPopup.updateLocation(input.getCaretOrigin().add(0, 13));
+                    completionPopup.setSuggestions(distinctCompletionSuggestions);
+                });
             });
         }
 
@@ -549,7 +547,7 @@ public class JavaCellFactory implements CellFactory {
 
         private void handleTabCompletion(String text, int caretPos, Point2D caretOrigin, Consumer<CompletionUpdate> consumer) {
             this.control.getSheet().getReactiveJShell().completionAsync(text, caretPos, result -> {
-                var distinctCompletionSuggestions = result.suggestions().stream().map(s -> CompletionItem.from(s, result.anchor())).distinct().toList();
+                var distinctCompletionSuggestions = result.suggestions().stream().map(CompletionItem::from).distinct().toList();
                 // no completions
                 if (distinctCompletionSuggestions.isEmpty()) {
                     Platform.runLater(() -> completionPopup.hide());
@@ -562,7 +560,16 @@ public class JavaCellFactory implements CellFactory {
                     String completableCommonPrefix = CompletionItem.longestCommonPrefix(distinctCompletionSuggestions);
                     if (!completableCommonPrefix.isEmpty()
                             && !text.substring(result.anchor(), caretPos).equals(completableCommonPrefix)) {
-                        Platform.runLater(() -> consumer.accept(convert(result.anchor(), caretPos, completableCommonPrefix)));
+                        Platform.runLater(() -> {
+                            consumer.accept(convert(result.anchor(), caretPos, completableCommonPrefix));
+                            completionPopup.setOnCompletion(event -> Platform.runLater(() -> consumer.accept(convert(event.getAnchor(), input.getCaretPosition(), event.getSuggestion()))));
+                            completionPopup.setSuggestions(distinctCompletionSuggestions);
+                            if (!completionPopup.isShowing()) {
+                                completionPopup.show(this.control.getScene().focusOwnerProperty().get(), input.getCaretOrigin().add(0, 13));
+                            } else {
+                                completionPopup.updateLocation(input.getCaretOrigin().add(0, 13));
+                            }
+                        });
                     } else {
                         completionPopup.setOnCompletion(event -> Platform.runLater(() -> consumer.accept(convert(event.getAnchor(), input.getCaretPosition(), event.getSuggestion()))));
                         Platform.runLater(() -> {

--- a/ui/src/main/java/org/jtaccuino/core/ui/completion/CompletionItem.java
+++ b/ui/src/main/java/org/jtaccuino/core/ui/completion/CompletionItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 JTaccuino Contributors
+ * Copyright 2025-2026 JTaccuino Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,13 @@
 package org.jtaccuino.core.ui.completion;
 
 import java.util.List;
-import jdk.jshell.SourceCodeAnalysis;
+import javax.lang.model.element.ElementKind;
+import org.jtaccuino.jshell.ReactiveJShell;
 
-public record CompletionItem(String completion, boolean matchesType, int anchor) {
+public record CompletionItem(String completion, boolean matchesType, int anchor,
+        ElementKind elementKind, boolean keyword, boolean staticMember, String displayName, String typeInfo) {
 
-    public static CompletionItem NIL = new CompletionItem("N/A", false, 0);
+    public static CompletionItem NIL = new CompletionItem("N/A", false, 0, null, false, false, "", "");
 
     public static String longestCommonPrefix(List<CompletionItem> completionItems) {
         return switch (completionItems) {
@@ -48,7 +50,8 @@ public record CompletionItem(String completion, boolean matchesType, int anchor)
         return !matchesType();
     }
 
-    public static CompletionItem from(SourceCodeAnalysis.Suggestion suggestion, int anchor) {
-        return new CompletionItem(suggestion.continuation(), suggestion.matchesType(), anchor);
+    public static CompletionItem from(ReactiveJShell.CompletionItem item) {
+        return new CompletionItem(item.completion(), item.matchesType(), item.anchor(), item.elementKind(), item.keyword(),
+                item.staticMember(), item.displayName(), item.typeInfo());
     }
 }

--- a/ui/src/main/java/org/jtaccuino/core/ui/completion/CompletionItemRenderer.java
+++ b/ui/src/main/java/org/jtaccuino/core/ui/completion/CompletionItemRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 JTaccuino Contributors
+ * Copyright 2025-2026 JTaccuino Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,15 @@ package org.jtaccuino.core.ui.completion;
 
 import javafx.collections.ObservableList;
 import javafx.css.PseudoClass;
+import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.Separator;
+import javafx.scene.layout.BorderPane;
 import javafx.util.Callback;
 
 class CompletionItemRenderer implements Callback<ListView<CompletionItem>, ListCell<CompletionItem>> {
@@ -38,18 +43,17 @@ class CompletionItemRenderer implements Callback<ListView<CompletionItem>, ListC
             @Override
             protected void updateItem(CompletionItem item, boolean empty) {
                 super.updateItem(item, empty);
-                setText(null != item ? item.completion() : "");
+                setText(null);
                 getStyleClass().removeAll("type-matches", "separator-cell");
                 if (empty) {
                     setGraphic(null);
                     setFocusTraversable(false);
                 } else if (CompletionItem.NIL.equals(item)) {
-                    setText(null);
                     setGraphic(separator);
                     getStyleClass().add("separator-cell");
                     setFocusTraversable(false);
                 } else {
-                    setGraphic(null);
+                    setGraphic(createContent(item));
                     setFocusTraversable(true);
                     if (item.matchesType()) {
                         getStyleClass().add("type-matches");
@@ -61,6 +65,46 @@ class CompletionItemRenderer implements Callback<ListView<CompletionItem>, ListC
                     pseudoClassStateChanged(PseudoClass.getPseudoClass("odd"), !isEven);
                 }
             }
+        };
+    }
+
+    private static Node createContent(CompletionItem item) {
+        var name = new Label(item.displayName());
+        name.getStyleClass().add("completion-name");
+        var type = new Label(item.typeInfo());
+        type.getStyleClass().add("completion-type");
+        var content = new BorderPane();
+        var icon = createIcon(item);
+        content.setLeft(icon);
+        BorderPane.setMargin(icon, new Insets(0, 6, 0, 0));
+        BorderPane.setAlignment(name, Pos.CENTER_LEFT);
+        content.setCenter(name);
+        content.setRight(type);
+        return content;
+    }
+
+    private static ElementKindIcon createIcon(CompletionItem item) {
+        var icon = new ElementKindIcon(item.elementKind(), item.keyword(), item.staticMember());
+        icon.getStyleClass().add(styleClass(item));
+        return icon;
+    }
+
+    private static String styleClass(CompletionItem item) {
+        if (item.keyword()) {
+            return "completion-icon-keyword";
+        }
+        return switch (item.elementKind()) {
+            case CLASS -> "completion-icon-class";
+            case INTERFACE -> "completion-icon-interface";
+            case ENUM, ENUM_CONSTANT -> "completion-icon-enum";
+            case RECORD -> "completion-icon-record";
+            case ANNOTATION_TYPE -> "completion-icon-annotation";
+            case METHOD, CONSTRUCTOR -> "completion-icon-method";
+            case FIELD -> "completion-icon-field";
+            case PACKAGE, MODULE -> "completion-icon-package";
+            case PARAMETER, LOCAL_VARIABLE, RESOURCE_VARIABLE, EXCEPTION_PARAMETER, TYPE_PARAMETER -> "completion-icon-variable";
+            case null -> "completion-icon-keyword";
+            default -> "completion-icon-keyword";
         };
     }
 }

--- a/ui/src/main/java/org/jtaccuino/core/ui/completion/CompletionPopup.java
+++ b/ui/src/main/java/org/jtaccuino/core/ui/completion/CompletionPopup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 JTaccuino Contributors
+ * Copyright 2024-2026 JTaccuino Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,10 @@ import javafx.event.EventHandler;
 import javafx.event.EventType;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
+import javafx.scene.Scene;
 import javafx.scene.control.PopupControl;
 import javafx.scene.control.Skin;
+import javafx.scene.input.MouseEvent;
 import javafx.stage.Window;
 
 public class CompletionPopup extends PopupControl {
@@ -112,7 +114,34 @@ public class CompletionPopup extends PopupControl {
                 node,
                 parent.getX() + localToScene.getX() + node.getScene().getX(),
                 parent.getY() + localToScene.getY() + node.getScene().getY());
+        syncStylesheets(node.getScene().getStylesheets());
         this.getOwnerNode();
+        installOutsideClickHider(node.getScene());
+    }
+
+    private void installOutsideClickHider(Scene scene) {
+        var ownerWindow = scene.getWindow();
+        ownerWindow.removeEventFilter(MouseEvent.MOUSE_PRESSED, outsideClickHider);
+        ownerWindow.addEventFilter(MouseEvent.MOUSE_PRESSED, outsideClickHider);
+    }
+
+    private final EventHandler<MouseEvent> outsideClickHider = event -> {
+        if (isShowing()) {
+            hide();
+        }
+    };
+
+    private void syncStylesheets(javafx.collections.ObservableList<String> ownerStylesheets) {
+        var popupScene = getScene();
+        if (popupScene == null || ownerStylesheets.isEmpty()) {
+            return;
+        }
+        var popupStylesheets = popupScene.getStylesheets();
+        for (var stylesheet : ownerStylesheets) {
+            if (!popupStylesheets.contains(stylesheet)) {
+                popupStylesheets.add(stylesheet);
+            }
+        }
     }
 
     public final void setVisibleCompletions(int value) {

--- a/ui/src/main/java/org/jtaccuino/core/ui/completion/CompletionPopupSkin.java
+++ b/ui/src/main/java/org/jtaccuino/core/ui/completion/CompletionPopupSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 JTaccuino Contributors
+ * Copyright 2024-2026 JTaccuino Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.collections.ListChangeListener;
 import javafx.event.Event;
-import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
 import javafx.scene.Node;
 import javafx.scene.control.ListView;
@@ -38,8 +37,6 @@ class CompletionPopupSkin implements Skin<CompletionPopup> {
     final int LIST_CELL_HEIGHT = 24;
 
     private final CompletionSelectionModel selectionModel;
-    private final double completionItemCharWidth;
-    private final double completionItemCharHeight;
 
     public CompletionPopupSkin(CompletionPopup control) {
         this.control = control;
@@ -47,18 +44,12 @@ class CompletionPopupSkin implements Skin<CompletionPopup> {
         selectionModel = new CompletionSelectionModel(control.getSuggestions());
         completionList.setSelectionModel(selectionModel);
 
-        Text tempText = new Text("Q");
-        tempText.setFont(Font.font("Monaspace Argon", 11));
-        Bounds charBounds = tempText.getLayoutBounds();
-        completionItemCharWidth = charBounds.getWidth();
-        completionItemCharHeight = charBounds.getHeight();
-
         completionList.prefHeightProperty().bind(
                 Bindings.min(control.visibleCompletionsProperty(), Bindings.size(completionList.getItems()))
-                        .multiply(Math.ceil(completionItemCharHeight*(1+0.25+0.25)+3)).add(2));
+                        .multiply(LIST_CELL_HEIGHT).add(2));
         completionList.maxHeightProperty().bind(
                 Bindings.min(control.visibleCompletionsProperty(), Bindings.size(completionList.getItems()))
-                        .multiply(Math.ceil(completionItemCharHeight*(1+0.25+0.25)+3)).add(2));
+                        .multiply(LIST_CELL_HEIGHT).add(2));
         completionList.setCellFactory(new CompletionItemRenderer(control.getSuggestions()));
 
         completionList.prefWidthProperty().bind(control.prefWidthProperty());
@@ -113,7 +104,7 @@ class CompletionPopupSkin implements Skin<CompletionPopup> {
             } else {
                 completionList.getSelectionModel().selectFirst();
                 var needsScrollBar = completionList.getItems().size() > getSkinnable().getVisibleCompletions();
-                double width = Math.min(calculateListViewPreferredWidth(needsScrollBar), 400);
+                double width = calculateListViewPreferredWidth(needsScrollBar);
                 getSkinnable().setMinWidth(width);
                 getSkinnable().setPrefWidth(width);
                 getSkinnable().setMaxWidth(width);
@@ -169,17 +160,39 @@ class CompletionPopupSkin implements Skin<CompletionPopup> {
             return Region.USE_PREF_SIZE;
         }
 
-        double maxWidth = control.getSuggestions()
-                .stream().mapToInt(c -> c.completion().length()).max().orElse(0) * completionItemCharWidth;
+        Font nameFont = Font.font("Monaspace Argon", 11);
+        Font typeFont = Font.font("Monaspace Argon", 10);
+        double maxNameWidth = 0;
+        double maxTypeWidth = 0;
+        for (CompletionItem item : control.getSuggestions()) {
+            if (CompletionItem.NIL.equals(item)) {
+                continue;
+            }
+            maxNameWidth = Math.max(maxNameWidth, measureText(item.displayName(), nameFont));
+            if (!item.typeInfo().isEmpty()) {
+                maxTypeWidth = Math.max(maxTypeWidth, measureText(item.typeInfo(), typeFont));
+            }
+        }
 
+        double completionIconAllowance = 24;
+        double nameTypeGap = 16;
         double cellHorizontalPadding = 10;
 
         Insets listViewPadding = completionList.getPadding();
         double totalListViewPadding = listViewPadding.getLeft() + listViewPadding.getRight();
 
-        double verticalScrollbarAllowance = 15;
+        double verticalScrollbarAllowance = needsScrollBar ? 15 : 0;
 
-        return maxWidth + cellHorizontalPadding + totalListViewPadding + (needsScrollBar ? verticalScrollbarAllowance : 0);
+        double contentWidth = maxNameWidth + (maxTypeWidth > 0 ? nameTypeGap + maxTypeWidth : 0);
+
+        return contentWidth + completionIconAllowance + cellHorizontalPadding
+                + totalListViewPadding + verticalScrollbarAllowance;
+    }
+
+    private static double measureText(String text, Font font) {
+        Text tempText = new Text(text);
+        tempText.setFont(font);
+        return tempText.getLayoutBounds().getWidth();
     }
 
     private void onSuggestionChoosen(String suggestion, int anchor) {

--- a/ui/src/main/java/org/jtaccuino/core/ui/completion/ElementKindIcon.java
+++ b/ui/src/main/java/org/jtaccuino/core/ui/completion/ElementKindIcon.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025-2026 JTaccuino Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jtaccuino.core.ui.completion;
+
+import javafx.scene.Group;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Circle;
+import javafx.scene.shape.Polygon;
+import javafx.scene.shape.Rectangle;
+import javafx.scene.shape.Shape;
+import javafx.scene.shape.StrokeType;
+import javax.lang.model.element.ElementKind;
+
+/**
+ * A 16x16 iconographic glyph for a Java element, rendered in the abstract
+ * shape language used by the Apache NetBeans completion popup: classes are a
+ * blue square with an amber diamond and a pink circle, methods a pink circle,
+ * fields two overlapping blue squares, constructors an amber diamond, and so
+ * on. The shape outlines are drawn in a translucent black as in NetBeans.
+ */
+public class ElementKindIcon extends Group {
+
+    private static final Color CLASS_BLUE = Color.web("#a7cdea");
+    private static final Color CLASS_AMBER = Color.web("#f0c373");
+    private static final Color CLASS_PINK = Color.web("#ffb0a9");
+    private static final Color CONSTANT_RED = Color.web("#ff7063");
+    private static final Color INTERFACE_SURFACE = Color.web("#e5e5e5");
+    private static final Color INTERFACE_BORDER = Color.web("#9a9a9a");
+    private static final Color VARIABLE_SURFACE = Color.web("#dde5ef");
+    private static final Color VARIABLE_BORDER = Color.web("#65727f");
+    private static final Color FOLDER_BODY = Color.web("#ecc66b");
+    private static final Color FOLDER_LINE = Color.web("#af9447");
+    private static final Color FOLDER_BORDER = Color.web("#775e20");
+    private static final Color FOLDER_HIGHLIGHT = Color.rgb(234, 212, 167, 0.5);
+    private static final Color FOLDER_LABEL = Color.web("#f5eedc");
+    private static final Color ANNOTATION_GREEN = Color.web("#6fae42");
+    private static final Color ANNOTATION_DOT = Color.web("#f5eedc");
+    private static final Color KEYWORD_RED = Color.web("#f7768e");
+    private static final Color UNKNOWN_GRAY = Color.web("#9a9a9a");
+    private static final Color SHAPE_BORDER = Color.rgb(0, 0, 0, 0.33);
+
+    @SuppressWarnings("this-escape")
+    public ElementKindIcon(ElementKind elementKind, boolean keyword, boolean staticMember) {
+        getStyleClass().add("completion-icon");
+        Rectangle canvas = new Rectangle(0, 0, 16, 16);
+        canvas.setFill(Color.TRANSPARENT);
+        canvas.setStroke(Color.TRANSPARENT);
+        getChildren().add(canvas);
+        if (keyword) {
+            addBadge(KEYWORD_RED);
+        } else if (elementKind == null) {
+            addBadge(UNKNOWN_GRAY);
+        } else {
+            switch (elementKind) {
+                case CLASS, RECORD -> classShape();
+                case INTERFACE -> interfaceShape();
+                case ENUM -> enumShape();
+                case ENUM_CONSTANT, FIELD, BINDING_VARIABLE -> fieldShape(staticMember);
+                case ANNOTATION_TYPE -> annotationShape();
+                case METHOD -> methodShape(staticMember);
+                case CONSTRUCTOR -> constructorShape();
+                case PACKAGE -> packageShape();
+                case MODULE, PARAMETER, LOCAL_VARIABLE, RESOURCE_VARIABLE,
+                        EXCEPTION_PARAMETER, TYPE_PARAMETER -> variableShape();
+                case null, default -> addBadge(UNKNOWN_GRAY);
+            }
+        }
+    }
+
+    private void classShape() {
+        addShape(new Rectangle(0, 6, 9, 9), CLASS_BLUE);
+        addShape(new Polygon(2, 5.5, 7.5, 0, 13, 5.5, 7.5, 11), CLASS_AMBER);
+        addShape(new Circle(11.5, 10.5, 4.5), CLASS_PINK);
+    }
+
+    private void interfaceShape() {
+        addShape(new Rectangle(3.5, 6.5, 7, 2), INTERFACE_SURFACE, INTERFACE_BORDER);
+        addShape(new Circle(12.5, 7.5, 3), INTERFACE_SURFACE, INTERFACE_BORDER);
+        addShape(new Circle(2.5, 7.5, 2), INTERFACE_SURFACE, INTERFACE_BORDER);
+    }
+
+    private void enumShape() {
+        addShape(new Rectangle(0, 5.864, 9, 9), CLASS_BLUE);
+        addShape(new Circle(11.5, 10.5, 4.5), CLASS_PINK);
+        addShape(new Polygon(11.5, 0, 7, 8, 16, 8), CONSTANT_RED);
+        addShape(new Polygon(0.034, 4.5, 4.534, 0, 9.034, 4.5, 4.534, 9), CLASS_AMBER);
+    }
+
+    private void methodShape(boolean staticMember) {
+        addShape(new Circle(8, 9.5, 5.5), CLASS_PINK);
+        if (staticMember) {
+            addStaticBar(CLASS_PINK);
+        }
+    }
+
+    private void constructorShape() {
+        addShape(new Polygon(2.5, 9.5, 8, 4, 13.5, 9.5, 8, 15), CLASS_AMBER);
+    }
+
+    private void fieldShape(boolean staticMember) {
+        addShape(new Rectangle(2.5, 4, 11, 11), CLASS_BLUE);
+        addShape(new Rectangle(2.5, 4, 11, 11), CLASS_BLUE);
+        if (staticMember) {
+            addStaticBar(CLASS_BLUE);
+        }
+    }
+
+    private void variableShape() {
+        addShape(new Rectangle(3.5, 2.5, 10, 10), VARIABLE_SURFACE, VARIABLE_BORDER);
+    }
+
+    private void annotationShape() {
+        addShape(new Rectangle(3.5, 3.5, 9, 9), ANNOTATION_GREEN);
+        addShape(new Circle(8, 8, 2.2), ANNOTATION_DOT, null);
+    }
+
+    private void packageShape() {
+        addShape(new Polygon(1, 15, 16, 15, 16, 4, 14, 1, 3, 1, 1, 4), FOLDER_BODY, FOLDER_BORDER);
+        addShape(new Polygon(16, 4, 14, 1, 3, 1, 1, 4, 2, 4.303, 15, 4.303), FOLDER_HIGHLIGHT, null);
+        addShape(new Rectangle(7.5, 4.3, 1, 10.7), FOLDER_LINE, null);
+        addShape(new Rectangle(1, 8.5, 15, 1), FOLDER_LINE, null);
+        addShape(new Rectangle(2, 4.303, 13, 0.697), FOLDER_LINE, null);
+        addShape(new Rectangle(11, 6, 3, 2), FOLDER_LABEL, null);
+    }
+
+    private void addBadge(Color fill) {
+        var badge = new Rectangle(4, 4, 8, 8);
+        badge.setArcWidth(2);
+        badge.setArcHeight(2);
+        addShape(badge, fill);
+    }
+
+    private void addStaticBar(Color fill) {
+        addShape(new Rectangle(6.5, 3, 3, 13), fill);
+    }
+
+    private void addShape(Shape shape, Color fill) {
+        addShape(shape, fill, SHAPE_BORDER);
+    }
+
+    private void addShape(Shape shape, Color fill, Color stroke) {
+        shape.setFill(fill);
+        shape.setStroke(stroke);
+        shape.setStrokeWidth(1);
+        shape.setStrokeType(StrokeType.INSIDE);
+        getChildren().add(shape);
+    }
+}

--- a/ui/src/main/java/org/jtaccuino/core/ui/documentation/DocumentationPopup.java
+++ b/ui/src/main/java/org/jtaccuino/core/ui/documentation/DocumentationPopup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 JTaccuino Contributors
+ * Copyright 2025-2026 JTaccuino Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,13 @@ import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.event.EventHandler;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
+import javafx.scene.Scene;
 import javafx.scene.control.PopupControl;
 import javafx.scene.control.Skin;
+import javafx.scene.input.MouseEvent;
 import javafx.stage.Window;
 
 public class DocumentationPopup extends PopupControl {
@@ -64,7 +67,20 @@ public class DocumentationPopup extends PopupControl {
                 parent.getX() + localToScene.getX() + node.getScene().getX(),
                 parent.getY() + localToScene.getY() + node.getScene().getY());
         this.getOwnerNode();
+        installOutsideClickHider(node.getScene());
     }
+
+    private void installOutsideClickHider(Scene scene) {
+        var ownerWindow = scene.getWindow();
+        ownerWindow.removeEventFilter(MouseEvent.MOUSE_PRESSED, outsideClickHider);
+        ownerWindow.addEventFilter(MouseEvent.MOUSE_PRESSED, outsideClickHider);
+    }
+
+    private final EventHandler<MouseEvent> outsideClickHider = event -> {
+        if (isShowing()) {
+            hide();
+        }
+    };
 
     public final void setVisibleDocumentations(int value) {
         visibleDocumentations.set(value);


### PR DESCRIPTION
- Bump toolchain to JDK 26 and JavaFX to 26
- Rework ReactiveJShell completion to the JDK 26 ElementSuggestion API
- Render completion entries with a NetBeans-style ElementKindIcon, bold type-matching names and right-aligned type info
